### PR TITLE
hal_gpio_h3_demo: enable fp in the slow thread

### DIFF
--- a/src/hal/drivers/hal_gpio_h3_demo.hal
+++ b/src/hal/drivers/hal_gpio_h3_demo.hal
@@ -2,7 +2,7 @@
 
 loadrt hal_gpio_h3 output_pins=3,5,7,8
 newthread fast 100000
-newthread slow 1000000
+newthread slow 1000000 fp
 
 loadrt stepgen step_type=5 ctrl_type=v 
 


### PR DESCRIPTION
as required by stepgen